### PR TITLE
thunderbird.desktop: added StartupWMClass=thunderbird-esr

### DIFF
--- a/installing-thunderbird-linux/thunderbird.desktop
+++ b/installing-thunderbird-linux/thunderbird.desktop
@@ -16,6 +16,7 @@ Icon=/opt/thunderbird/chrome/icons/default/default128.png
 Categories=Application;Network;Email;
 MimeType=x-scheme-handler/mailto;application/x-xpinstall;
 StartupNotify=true
+StartupWMClass=thunderbird-esr
 Actions=Compose;Contacts
 
 [Desktop Action Compose]


### PR DESCRIPTION
- fixes #6 

More details are in the discussion of the issue. I've tested the fix on this setup using X11:
Pop!_OS 22.04 LTS
GNOME version 42.9
Window System: X11
Thunderbird 128.1.0esr (64-bit)

Another person tested on Wayland:
Fedora 40
Gnome 46
Wayland
Thunderbird 128.1.0esr (64-bit)

Note:
This fix potentially only works for the Thunderbird ESR version... I'm not sure if we could make it work for beta branches etc. as well with just one `Thunderbird.desktop` file... Further testing would be required with non-ESR versions.

Alternatively we could also just mention this behavior in the installation instructions in the mozilla KB that refers to this file. Since those instructions are meant for advanced users after all, they could at least easily fix it themselves as needed.