### PR TITLE
add StartupWMClass to thunderbird.desktop

### DIFF
--- a/installing-thunderbird-linux/thunderbird.desktop
+++ b/installing-thunderbird-linux/thunderbird.desktop
@@ -17,6 +17,7 @@ Categories=Application;Network;Email;
 MimeType=x-scheme-handler/mailto;application/x-xpinstall;
 StartupNotify=true
 Actions=Compose;Contacts
+StartupWMClass=thunderbird-esr
 
 [Desktop Action Compose]
 Name=Compose New Message


### PR DESCRIPTION
StartupWMClass is needed because executable name is 'thunderbird' but the application identifies itself as 'thunderbird-esr'. Without this property the window as no icon in the dash and GNOME doesn't know the app is already launched.